### PR TITLE
Row reduction and copy magics

### DIFF
--- a/mytrix/matrix.py
+++ b/mytrix/matrix.py
@@ -1,5 +1,6 @@
 """Module for general matrix class."""
 
+from copy import deepcopy
 import random
 
 import exceptions as exc
@@ -52,6 +53,26 @@ class Matrix:
                 if self[i, j] != mtrx[i, j]:
                     return False
         return True
+
+    def __copy__(self):
+        """Create a shallow copy of this matrix.
+
+        Creates a new instance of Matrix but with data referencing the data
+        of the original matrix.
+        """
+        res = Matrix(self.m, self.n, init=False)
+        res.data = self.data
+        return res
+
+    def __deepcopy__(self, memodict={}):
+        """Create a deep copy of this matrix.
+
+        Creates a new instance of Matrix with data copied from the original
+        matrix.
+        """
+        res = Matrix(self.m, self.n, init=False)
+        res.data = deepcopy(self.data)
+        return res
 
     def __add__(self, obj):
         """Add a valid object to this matrix and return the result.

--- a/mytrix/matrix.py
+++ b/mytrix/matrix.py
@@ -280,6 +280,53 @@ class Matrix:
         skew = (self - self.transpose()) * .5
         return sym, skew
 
+    def row_reduce(self):
+        """Return the row-reduced form of this matrix."""
+        res = self.row_echelon()
+        for i in range(1, res.m):
+            for j in range(res.n):
+                if res[i, j] == 1:
+                    for k in range(i):
+                        constant = res[k, j]
+                        res.data[k] = [elem_k - elem_i * constant
+                                       for elem_i, elem_k in
+                                       zip(res.data[i], res.data[k])]
+                    break
+        return res
+
+    def row_echelon(self):
+        """Return the row-echelon form of this matrix."""
+        # TODO: This can be refactored for better efficiency
+        if all([all([self[i, j] == 0 for j in range(self.n)])
+                for i in range(self.m)]):
+            return Matrix.makeZero(self.m, self.n)
+        res = deepcopy(self)
+        i, j = 0, 0
+        while i < res.m and j < res.n:
+            # Use R2 to make pivot non-zero
+            if res[i, j] == 0:
+                found_non_zero = False
+                for k in range(i, res.m):
+                    if res[k, j] != 0:
+                        found_non_zero = True
+                        break
+                if not found_non_zero:
+                    j += 1
+                    continue
+                res.data[i], res.data[k] = res.data[k], res.data[i]
+            # Use R3 to make pivot one
+            if res[i, j] != 1:
+                res.data[i] = [elem / res[i, j] for elem in res.data[i]]
+            # Use R1 to eliminate entries below the pivot
+            for k in range(i + 1, res.m):
+                if res[k, j] != 0:
+                    constant = res[k, j] / res[i, j]
+                    res.data[k] = [elem_k - elem_i * constant
+                                   for elem_i, elem_k in
+                                   zip(res.data[i], res.data[k])]
+            i, j = i + 1, j + 1
+        return res
+
     @classmethod
     def makeRandom(cls, m, n, min=0, max=1):
         """Create random matrix.
@@ -302,7 +349,7 @@ class Matrix:
         """Make an identity matrix of dimension m by m."""
         obj = Matrix(m, m, init=False)
         for i in range(m):
-            obj.data.append([1 if i == j else 1 for j in range(m)])
+            obj.data.append([1 if i == j else 0 for j in range(m)])
         return obj
 
     @classmethod

--- a/mytrix/matrix_tests.py
+++ b/mytrix/matrix_tests.py
@@ -1,5 +1,6 @@
 """Module for testing general matrix class."""
 
+from copy import copy, deepcopy
 import unittest
 
 from matrix import Matrix
@@ -32,6 +33,22 @@ class MatrixTests(unittest.TestCase):
         # test initialising with invalid init
         with self.assertRaises(TypeError):
             Matrix(2, 2, 'spam')
+
+    def testCopy(self):
+        """Test shallow and deep copying."""
+        # test shallow copying
+        m1 = Matrix.fromRows([[1, 2], [3, 4]])
+        m2 = copy(m1)
+        self.assertTrue(m2 is not m1)
+        m2[1, 1] = 5
+        self.assertTrue(m1[1, 1] == 5)
+
+        # test deep copying
+        m1 = Matrix.fromRows([[1, 2], [3, 4]])
+        m2 = deepcopy(m1)
+        self.assertTrue(m2 is not m1)
+        m2[1, 1] = 5
+        self.assertTrue(m1[1, 1] == 4)
 
     def testStr(self):
         """Test string method."""

--- a/mytrix/matrix_tests.py
+++ b/mytrix/matrix_tests.py
@@ -244,6 +244,45 @@ class MatrixTests(unittest.TestCase):
         with self.assertRaises(exc.DecompositionError):
             m2.toeplitz_decomposition()
 
+    def testRowReduction(self):
+        """Test reduction to row-reduced and row-echelon form."""
+        # test reduction to row-echelon form
+        m1 = Matrix.fromRows([[1, 2], [3, 4]])
+        self.assertTrue(m1.row_echelon() == Matrix.fromRows([[1, 2], [0, 1]]))
+
+        # test reduction to row-echelon form on the zero matrix
+        m2 = Matrix.makeZero(2, 2)
+        self.assertTrue(m2.row_echelon() == Matrix.makeZero(2, 2))
+
+        # test reduction to row-echelon form on the matrix with only one row
+        m3 = Matrix.fromRows([[1, 2, 3, 4]])
+        self.assertTrue(m3.row_reduce() == Matrix.fromRows([[1, 2, 3, 4]]))
+
+        # test reduction to row-echelon form on the matrix with only one column
+        m4 = Matrix.fromRows([[1], [2], [3], [4]])
+        self.assertTrue(m4.row_reduce() == Matrix.fromRows([[1], [0],
+                                                            [0], [0]]))
+
+        # test idompotency of reduction to row-echelon form
+        self.assertTrue(m1.row_echelon() == m1.row_echelon().row_echelon())
+
+        # test row reduction
+        self.assertTrue(m1.row_reduce() == Matrix.makeIdentity(2))
+
+        # test row reduction on the zero matrix
+        self.assertTrue(m2.row_reduce() == Matrix.makeZero(2, 2))
+
+        # test row reduction on the matrix with only one row
+        m3 = Matrix.fromRows([[1, 2, 3, 4]])
+        self.assertTrue(m3.row_reduce() == Matrix.fromRows([[1, 2, 3, 4]]))
+
+        # test row reduction on the matrix with only one column
+        self.assertTrue(m4.row_reduce() == Matrix.fromRows([[1], [0],
+                                                            [0], [0]]))
+
+        # test idompotency of reduction to row-echelon form
+        self.assertTrue(m1.row_reduce() == m1.row_reduce().row_reduce())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Initially planned to add just row reduction/row-echelon form but require `__copy__()` and `__deepcopy__()` magics to do so. Hence both are added.

This solves #20, #21